### PR TITLE
Prevent username and password from being leaked in logs when timeouts…

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -105,7 +105,8 @@ rescue LoadError
           if IO.select([self], nil, nil, options[:socket_timeout])
             retry
           else
-            raise Timeout::Error, "IO timeout: #{options.inspect}"
+            safe_options = options.reject{|k,v| [:username, :password].include? k}
+            raise Timeout::Error, "IO timeout: #{safe_options.inspect}"
           end
         end
         value


### PR DESCRIPTION
… are raised

The offending line of code
```
https://github.com/petergoldstein/dalli/blob/0af0200475db5ab6aa551dae026
a932f6fece210/lib/dalli/server.rb#L223
```

example of leaked creds in logs: 
```
Oct 17 04:22:52 production***/web.2:  ****.prod.memcachier.com:11211 failed (count: 0) Timeout::Error: IO timeout: {:host=>"****.memcachier.com", :port=>11211, :down_retry_delay=>1, :socket_timeout=>0.5, :socket_max_failures=>2, :socket_failure_delay=>0.01, :value_max_bytes=>1048576, :compressor=>Dalli::Compressor, :compression_min_size=>1024, :compression_max_size=>false, :serializer=>Marshal, :username=>"****", :password=>"****", :keepalive=>true, :sndbuf=>nil, :rcvbuf=>nil, :compress=>true, :threadsafe=>false, :pool_size=>5} 
```